### PR TITLE
Update documentation to clarify host protocol for authentication

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ provider "edge" {
 
 ### Optional
 
-- **host** (String) Edge router URL. Can be set with `EDGE_HOST`.
+- **host** (String) Edge router URL. Can be set with `EDGE_HOST`. Needs to be specified using the HTTPS protocol.
 - **insecure** (Boolean) Specify if the connection to the Edge configuration API should be insecure. Can be set with `EDGE_INSECURE`.
 - **password** (String, Sensitive) Admin password. Can be set with `EDGE_PASSWORD`.
 - **username** (String) Admin username. Can be set with `EDGE_USERNAME`.


### PR DESCRIPTION
I happened upon this issue when trying out your provider. If you specify the host using http, the edgerouter will return a XML response stating that go could not unmarshal the payload. Please see below:

```
Error: There was an issue creating the firewall port group.
│ 
│   with edge_firewall_port_group.whitelist,
│   on main.tf line 20, in resource "edge_firewall_port_group" "whitelist":
│   20: resource "edge_firewall_port_group" "whitelist" {
│ 
│ Could not unmarshal operation from data 
│     <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
│     <html>
│         <head>
│             <title>Error: 405 Method Not Allowed</title>
│             <style type="text/css">
│               html {background-color: #eee; font-family: sans;}
│               body {background-color: #fff; border: 1px solid #ddd;
│                     padding: 15px; margin: 15px;}
│               pre {background-color: #eee; border: 1px solid #ddd; padding: 5px;}
│             </style>
│         </head>
│         <body>
│             <h1>Error: 405 Method Not Allowed</h1>
│             <p>Sorry, the requested URL <tt>&#039;https://192.168.1.1/api/edge/batch.json&#039;</tt>
│                caused an error:</p>
│             <pre>Method not allowed.</pre>
│         </body>
│     </html>
│ : invalid character '<' looking for beginning of value

```